### PR TITLE
[FE] 헤더 레이아웃 수정

### DIFF
--- a/client/src/components/layout/FullScreenModal/style.ts
+++ b/client/src/components/layout/FullScreenModal/style.ts
@@ -8,7 +8,8 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
-  background-color: #171717;
+  background-color: ${({ theme }) => theme.COLOR['gray-6']};
+  color: ${({ theme }) => theme.COLOR['white']};
 `;
 
 const TitleSection = styled.div<{ isTitle: boolean }>`

--- a/client/src/components/layout/FullScreenModal/style.ts
+++ b/client/src/components/layout/FullScreenModal/style.ts
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   width: 100%;
   position: relative;
-  padding-top: 60px;
+  padding-top: 4rem;
+  padding-bottom: 3rem;
   min-height: 100vh;
   display: flex;
   align-items: center;

--- a/client/src/components/layout/HeaderLayout/HeaderLayout.tsx
+++ b/client/src/components/layout/HeaderLayout/HeaderLayout.tsx
@@ -3,17 +3,14 @@ import S from './style';
 
 type HeaderLayoutProps = {
   children: React.ReactNode;
-  $isContentBox: boolean;
 };
 //헤더 레이아웃
 //isContentBox : 뒤에 연한 배경색이 있는가? boolean 타입으로 지정
-const HeaderLayout = ({ children, $isContentBox }: HeaderLayoutProps) => {
+const HeaderLayout = ({ children }: HeaderLayoutProps) => {
   return (
     <S.Wrapper>
       <Header />
-      <S.ContentWrapper $isContentBox={$isContentBox}>
-        {children}
-      </S.ContentWrapper>
+      <S.ContentWrapper>{children}</S.ContentWrapper>
     </S.Wrapper>
   );
 };

--- a/client/src/components/layout/HeaderLayout/style.ts
+++ b/client/src/components/layout/HeaderLayout/style.ts
@@ -8,7 +8,6 @@ const Wrapper = styled.div`
   min-height: 100vh;
   width: 100%;
   flex-grow: 1; /* 자식 요소에 맞게 늘어나도록 설정 */
-  margin-bottom: 100px;
 `;
 
 const HeaderWrapper = styled.div`

--- a/client/src/components/layout/HeaderLayout/style.ts
+++ b/client/src/components/layout/HeaderLayout/style.ts
@@ -18,7 +18,7 @@ const HeaderWrapper = styled.div`
 `;
 
 const IconBox = styled.div<{ padding?: number }>`
-  background-color: ${({ theme }) => theme.COLOR['gray-8']};
+  background-color: ${({ theme }) => theme.COLOR['gray-5']};
   height: inherit;
   width: 160px;
   border-radius: 15px;
@@ -34,14 +34,12 @@ const SpaceBox = styled.div`
   width: calc(100% - 320px);
   min-width: 200px;
   height: inherit;
-  background-color: ${({ theme }) => theme.COLOR['gray-8']};
+  background-color: ${({ theme }) => theme.COLOR['gray-5']};
   ${flexCenter};
   border-radius: 15px;
 `;
 
-const ContentWrapper = styled.div<{ $isContentBox: boolean }>`
-  background-color: ${({ theme, $isContentBox }) =>
-    $isContentBox ? theme.COLOR['gray-8'] : 'none'};
+const ContentWrapper = styled.div`
   margin: 10px 32px 32px 32px;
   border-radius: 30px;
   min-height: 100vh;

--- a/client/src/pages/CreatePost/style.ts
+++ b/client/src/pages/CreatePost/style.ts
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components';
 import { flexCenter } from '@/styles/common';
 
 const Wrapper = styled.div<{ width?: string }>`
-  padding-top: 10px;
   display: flex;
   justify-content: center;
   width: 100%;

--- a/client/src/pages/CreatePost/style.ts
+++ b/client/src/pages/CreatePost/style.ts
@@ -7,6 +7,7 @@ const Wrapper = styled.div<{ width?: string }>`
   justify-content: center;
   width: 100%;
   height: 100%;
+  color: ${({ theme }) => theme.COLOR.white};
 `;
 
 const GridWrapper = styled.div`

--- a/client/src/pages/CreateSpace/style.ts
+++ b/client/src/pages/CreateSpace/style.ts
@@ -4,6 +4,8 @@ const Wrapper = styled.div`
   width: 50%;
   padding-top: 2rem;
   padding-bottom: 2.5rem;
+  color: white;
+
   display: grid;
   grid-template-columns: 1fr 2.5fr;
   grid-template-rows: 160px 60px 160px 60px 44px;

--- a/client/src/pages/InviteCode/style.ts
+++ b/client/src/pages/InviteCode/style.ts
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 const Form = styled.form`
-  background-color: ${({ theme }) => theme.COLOR['gray-7']};
   width: 50%;
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;

--- a/client/src/pages/mainPage/index.tsx
+++ b/client/src/pages/mainPage/index.tsx
@@ -1,17 +1,29 @@
-import MainHeader, {MainHeaderPropType} from "@pages/mainPage/components/MainHeader/MainHeader";
-import MainBody, {MainBodyPropType} from "@pages/mainPage/components/MainBody/MainBody";
-import S from "@pages/mainPage/style";
-
-export type MainPageType = (MainHeaderPropType & MainBodyPropType);
+import MainHeader, {
+  MainHeaderPropType,
+} from '@pages/MainPage/components/MainHeader/MainHeader';
+import MainBody, {
+  MainBodyPropType,
+} from '@pages/MainPage/components/MainBody/MainBody';
+import S from '@pages/MainPage/style';
+import HeaderLayout from '@/components/layout/HeaderLayout/HeaderLayout';
+export type MainPageType = MainHeaderPropType & MainBodyPropType;
 
 const MainPage = (props: MainPageType) => {
-    const {spaceInfo, userList, tagList, postList, total, page} = props;
-    return (
-        <S.Wrapper>
-            <MainHeader spaceInfo={spaceInfo}/>
-            <MainBody userList={userList} tagList={tagList} total={total} postList={postList} page={page}/>
-        </S.Wrapper>
-    );
+  const { spaceInfo, userList, tagList, postList, total, page } = props;
+  return (
+    <HeaderLayout>
+      <S.Wrapper>
+        <MainHeader spaceInfo={spaceInfo} />
+        <MainBody
+          userList={userList}
+          tagList={tagList}
+          total={total}
+          postList={postList}
+          page={page}
+        />
+      </S.Wrapper>
+    </HeaderLayout>
+  );
 };
 
 export default MainPage;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 연관된 이슈 번호를 모두 작성해주세요

#28 

## 📝작업 내용

- 메인에 헤더 레이아웃이 적용되게 하고, 일부 css를 수정하였습니다

## 💬리뷰 요구사항(선택)

- 메인페이지의  OnePost의 사이즈가 px로 고정되어 있어서, 화면에 따라 한 줄에 보이는 개수가 다르게 나옵니다. 
- 그리드로 수정하시면 UI가 통일되어 좋을 것 같습니다.!
